### PR TITLE
Remove invalid comment in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,3 @@
-# The official style guide for Mqtty is this:
-#
-#   Try to match the existing code style and don't worry about it
-#   too much.
-#
-# Please don't submit changes to enable pep8 style checks or change
-# the code to match pep8 guidelines.  Mqtty should be fun to work on
-# and it shouldn't be hard to go with the flow and not worry too much
-# about whitespace.
-#
-# Pyflakes on the other hand is a useful system that often catches
-# real bugs and errors.  Flake8 is used to invoke pyflakes because it
-# supports the "NOQA" flag.
-
 [tox]
 minversion = 1.6
 skipsdist = True


### PR DESCRIPTION
I decided to apply pep8 instead of pyflakes. I think pep8 style checks are useful for beautiful code, and, that makes avoiding bugs.