### PR TITLE
Remove SideCI description from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,5 +40,5 @@ So, you can use it like this::
 Development
 -----------
 
-* Need to pass CircleCI and SideCI service check
+* Need to pass CircleCI service check
 


### PR DESCRIPTION
This commit removes SideCI description because it is duplicated to tox
pep8.